### PR TITLE
Use ipaddress module instead of ipaddr

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Extract files:
 Install, on a Debian or Ubuntu machine:
 
     $ sudo apt-get update
-    $ sudo apt-get install python3 python3-netaddr python3-ipaddr
+    $ sudo apt-get install python3 python3-netaddr
     $ sudo python3 setup.py install
 
 This will install the netstat-monitor exe to /usr/local/bin/ and the netstat.py module to /usr/local/lib/python3.2/dist-packages/.

--- a/netstat.py
+++ b/netstat.py
@@ -41,7 +41,7 @@ import configparser
 import datetime
 import errno
 import glob
-import ipaddr
+import ipaddress
 import netaddr
 import os
 import platform
@@ -345,13 +345,13 @@ class SocketInfo():
     @staticmethod
     def _is_ip_addr_private(addr_str):
         """Determine if IP address addr is a private address."""
-        addr = ipaddr.IPAddress(addr_str)
+        addr = ipaddress.ip_address(addr_str)
         return addr.is_private
 
     @staticmethod
     def _is_ip_addr_loopback(addr_str):
         """Determine if IP address addr is localhost."""
-        addr = ipaddr.IPAddress(addr_str)
+        addr = ipaddress.ip_address(addr_str)
         return addr.is_loopback
     
     @staticmethod
@@ -396,7 +396,7 @@ class SocketInfo():
                 octets = [colons[30:32], colons[32:34], colons[35:37], colons[37:39]]
                 dec_str = ".".join([str(int(octet, 16)) for octet in octets])
             else:
-                addr = ipaddr.IPv6Address(colons)
+                addr = ipaddress.IPv6Address(colons)
                 dec_str = str(addr)
         else:
             raise MonitorException("ERROR: Invalid IP address {0}".format(hex_str))


### PR DESCRIPTION
ipaddress is part of the Python 3 standard lib, and is a more
recent fork of ipaddr. A Python 2 backport is available in pypi
if anyone needs to run this on Python 2 for some reason. ipaddr
upstream is not compatible with Python 3, and hasn't merged a
pull request for Python 3 compatibility that's been open for
several months.